### PR TITLE
bugfix: 弹幕时间轴平滑、播放/直播菜单焦点定位，及构建与仓库优化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ app/src/main/res/values-watch/styles.xml
 *.seed
 AGENTS.md
 app/debug/output-metadata.json
+.codebuddy/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,7 +50,8 @@ android {
     compileSdk = 35
 
     defaultConfig {
-        applicationId = "com.tutu.myblbl"
+        // 默认包名；可通过 -PapplicationId=xxx 覆盖，用于 fork 版与原版共存安装
+        applicationId = (project.findProperty("applicationId") as? String) ?: "com.tutu.myblbl"
         minSdk = 23
         targetSdk = 35
         versionCode = 70

--- a/app/src/main/java/com/tutu/myblbl/core/ui/base/BaseListFragment.kt
+++ b/app/src/main/java/com/tutu/myblbl/core/ui/base/BaseListFragment.kt
@@ -173,12 +173,18 @@ abstract class BaseListFragment<MODEL> : BaseFragment<FragmentBaseListBinding>()
 
     override fun onResume() {
         super.onResume()
-        if (tvFocusController?.restoreCapturedAnchor() != true) {
-            // allowWhenFocusOutside=false：焦点已落在列表外的可见可聚焦 View（如侧边栏功能按钮）
-            // 时不再抢回焦点。焦点为 null/detached/hidden 时 ensureValidFocus 内部仍会恢复。
-            // 从播放器返回的焦点恢复由 MainActivity.restoreFocusAfterOverlayPop 负责。
-            tvFocusController?.ensureValidFocus("resume", allowWhenFocusOutside = false)
-        }
+        val controller = tvFocusController ?: return
+        // 从播放器等外部页面返回：用 restoreFocusAfterReturn 强制拉回捕获锚点，
+        // 并以 hasFocusInList 轮询确认真实焦点落点（覆盖转场动画窗口），避免焦点停在
+        // 返回按钮或彻底丢失。无锚点/重试耗尽时退回 ensureValidFocus 既有逻辑。
+        controller.restoreFocusAfterReturn(
+            onRestored = {},
+            onFailed = {
+                // allowWhenFocusOutside=false：焦点已落在列表外的可见可聚焦 View（如侧边栏功能按钮）
+                // 时不再抢回焦点。焦点为 null/detached/hidden 时 ensureValidFocus 内部仍会恢复。
+                tvFocusController?.ensureValidFocus("resume", allowWhenFocusOutside = false)
+            }
+        )
     }
 
     private fun setupSwipeRefresh() {
@@ -360,9 +366,11 @@ abstract class BaseListFragment<MODEL> : BaseFragment<FragmentBaseListBinding>()
     override fun onHiddenChanged(hidden: Boolean) {
         super.onHiddenChanged(hidden)
         if (!hidden) {
-            if (tvFocusController?.restoreCapturedAnchor() != true) {
-                tvFocusController?.ensureValidFocus("shown")
-            }
+            val controller = tvFocusController ?: return
+            controller.restoreFocusAfterReturn(
+                onRestored = {},
+                onFailed = { tvFocusController?.ensureValidFocus("shown") }
+            )
         }
     }
 

--- a/app/src/main/java/com/tutu/myblbl/core/ui/focus/VideoCardFocusHelper.kt
+++ b/app/src/main/java/com/tutu/myblbl/core/ui/focus/VideoCardFocusHelper.kt
@@ -229,6 +229,22 @@ object VideoCardFocusHelper {
                     return result
                 }
                 if (rv != null) {
+                    // 网格：优先用“下一行同列”算法，避免退化为 FocusFinder 空间查找导致跳行不稳定。
+                    // 标准网格下等价于 pos + spanCount；若未命中（非标准网格/到底部）再回退 FocusFinder。
+                    val lm = rv.layoutManager
+                    if (lm is GridLayoutManager && pos != RecyclerView.NO_POSITION) {
+                        val targetPos = resolveGridDownPosition(
+                            lm = lm,
+                            position = pos,
+                            itemCount = rv.adapter?.itemCount ?: 0
+                        )
+                        AppLog.d(TAG, "DPAD_DOWN pos=$pos grid down target=$targetPos")
+                        if (targetPos != RecyclerView.NO_POSITION) {
+                            if (requestGridDownFocus(rv, targetPos, lm)) {
+                                return true
+                            }
+                        }
+                    }
                     val nextFocus = FocusFinder.getInstance().findNextFocus(rv, target, View.FOCUS_DOWN)
                     AppLog.d(TAG, "DPAD_DOWN pos=$pos FocusFinder next=${
                         nextFocus?.let {
@@ -384,6 +400,60 @@ object VideoCardFocusHelper {
 
             else -> false
         }
+    }
+
+    private fun resolveGridDownPosition(
+        lm: GridLayoutManager,
+        position: Int,
+        itemCount: Int
+    ): Int {
+        if (position == RecyclerView.NO_POSITION || itemCount <= 0) {
+            return RecyclerView.NO_POSITION
+        }
+        val spanCount = lm.spanCount
+        val currentGroup = lm.spanSizeLookup.getSpanGroupIndex(position, spanCount)
+        val currentColumn = lm.spanSizeLookup.getSpanIndex(position, spanCount)
+        var i = position + 1
+        while (i < itemCount) {
+            val group = lm.spanSizeLookup.getSpanGroupIndex(i, spanCount)
+            if (group > currentGroup) {
+                // 若跨过超过一行，说明网格存在跨列 item 导致无法精确计算，交由 FocusFinder 兜底
+                if (group != currentGroup + 1) {
+                    return RecyclerView.NO_POSITION
+                }
+                if (lm.spanSizeLookup.getSpanIndex(i, spanCount) == currentColumn) {
+                    return i
+                }
+            }
+            i++
+        }
+        return RecyclerView.NO_POSITION
+    }
+
+    private fun requestGridDownFocus(
+        rv: RecyclerView,
+        position: Int,
+        lm: GridLayoutManager
+    ): Boolean {
+        val holder = rv.findViewHolderForAdapterPosition(position)
+        if (holder != null) {
+            val itemView = holder.itemView
+            if (itemView.isAttachedToWindow && itemView.isShown && itemView.isFocusable) {
+                return itemView.requestFocus()
+            }
+        }
+        // 目标 ViewHolder 未附着：先滚动到目标行，再在下一帧请求焦点
+        if (!rv.isComputingLayout) {
+            lm.scrollToPosition(position)
+        }
+        rv.post {
+            if (!rv.isAttachedToWindow) return@post
+            val h = rv.findViewHolderForAdapterPosition(position)
+            if (h != null && h.itemView.isAttachedToWindow && h.itemView.isShown && h.itemView.isFocusable) {
+                h.itemView.requestFocus()
+            }
+        }
+        return true
     }
 
     private fun View.findParentRecyclerView(): RecyclerView? {

--- a/app/src/main/java/com/tutu/myblbl/core/ui/focus/tv/TvListFocusController.kt
+++ b/app/src/main/java/com/tutu/myblbl/core/ui/focus/tv/TvListFocusController.kt
@@ -345,6 +345,30 @@ class TvListFocusController(
         return focusPosition(position, anchor.offsetTop, "request", allowOutsideFocus = allowOutsideFocus)
     }
 
+    /**
+     * 列表内当前是否已有真实焦点（含子项）。
+     * 用于"从播放器等外部页面返回后"判断焦点恢复是否真正成功：
+     * - `requestFocusPosition` 的返回值不可靠（内部失败时也会返回 true），
+     *   因此恢复成功与否需以真实焦点落点为准。
+     * - 返回 true 表示焦点已在列表内（用户可继续 D-pad 导航），
+     *   即使未精确落在目标卡片上也算恢复成功；否则上层应兜底重试/聚焦返回键。
+     */
+    fun hasFocusInList(): Boolean {
+        val focused = recyclerView.rootView?.findFocus() ?: return false
+        return isDescendantOf(focused, recyclerView)
+    }
+
+    /**
+     * 是否已捕获有效的返回锚点（`capturedAnchor`）。
+     * 点击卡片进入播放时会调用 [captureCurrentAnchor] 记录锚点；该锚点独立于
+     * 上层 Fragment 的 `lastFocusedPosition`，不会因"返回按钮获得焦点"等动作被清空，
+     * 是从播放器返回后恢复焦点的最可靠依据。
+     */
+    fun hasCapturedAnchor(): Boolean {
+        if (capturedAnchor != null) return true
+        return currentAnchor != null && resolveAnchorPosition(currentAnchor!!) != RecyclerView.NO_POSITION
+    }
+
     fun captureCurrentAnchor(): Boolean {
         val focused = recyclerView.rootView?.findFocus()
         val position = focused?.let(::resolveAdapterPosition) ?: RecyclerView.NO_POSITION
@@ -368,6 +392,27 @@ class TvListFocusController(
         }
         logD("captureCurrentAnchor: hasRealFocus=$hasRealFocus pos=$position focused=${describeView(focused)} capturedPos=${capturedAnchor?.adapterPosition} capturedKey=${capturedAnchor?.stableKey}")
         return hasRealFocus
+    }
+
+    /**
+     * 从播放器等外部页面返回时，将焦点恢复到点击时捕获的锚点位置。
+     *
+     * 区别于 [restoreCapturedAnchor]：
+     * - [restoreCapturedAnchor] 会因"焦点已落在列表外部可见 View 上"（如返回按钮）而跳过——
+     *   该逻辑是为侧边栏场景设计的；但"从播放器返回"时，焦点若落在返回按钮等外部控件上
+     *   恰恰是需要拉回列表的，跳过会直接导致焦点停在返回按钮。
+     * - 本方法强制把焦点拉回捕获锚点位置（`allowOutsideFocus = true` 绕过外部焦点 BLOCKED 检查），
+     *   是返回恢复焦点最可靠的入口。
+     */
+    fun restoreCapturedFocusPosition(): Boolean {
+        val anchor = capturedAnchor ?: currentAnchor ?: return false
+        val position = resolveAnchorPosition(anchor)
+        if (position == RecyclerView.NO_POSITION || !adapter.isFocusablePosition(position)) {
+            logD("restoreCapturedFocusPosition: pos=$position NOT focusable, skip")
+            return false
+        }
+        logD("restoreCapturedFocusPosition: pos=$position offset=${anchor.offsetTop}")
+        return focusPosition(position, anchor.offsetTop, "returnFocus", allowOutsideFocus = true)
     }
 
     fun restoreCapturedAnchor(): Boolean {

--- a/app/src/main/java/com/tutu/myblbl/core/ui/focus/tv/TvListFocusController.kt
+++ b/app/src/main/java/com/tutu/myblbl/core/ui/focus/tv/TvListFocusController.kt
@@ -415,6 +415,78 @@ class TvListFocusController(
         return focusPosition(position, anchor.offsetTop, "returnFocus", allowOutsideFocus = true)
     }
 
+    /**
+     * 从播放器等外部页面返回时，将焦点恢复到列表内的统一入口（供各 Fragment 的 onResume/onHiddenChanged 复用）。
+     *
+     * 背景：`restoreCapturedAnchor` 会因"焦点已落在列表外部可见 View（如返回按钮）"而跳过，且其
+     * 注释错误地假设"从播放器返回的焦点恢复走 MainActivity.restoreFocusAfterOverlayPop"——但播放器
+     * （PlayerActivity / LivePlayerActivity / CctvPlayerActivity）是独立 Activity，返回走 finish()，
+     * `restoreFocusAfterOverlayPop` 并不触发，导致焦点停在返回按钮或彻底丢失。
+     *
+     * 本方法：
+     * 1. 用 [restoreCapturedFocusPosition] 强制把焦点拉回捕获锚点位置（绕过外部焦点 BLOCKED 检查）；
+     * 2. 以 [hasFocusInList] 轮询**真实焦点落点**，覆盖 Activity 转场动画 / 布局未就绪窗口
+     *    （真机大屏动画可能 >250ms，原 `scheduleAttachRetry` 250ms 窗口不足）；
+     * 3. 成功回调 [onRestored]，无锚点或重试耗尽回调 [onFailed]（由上层决定兜底）。
+     *
+     * 安全性：一旦用户开始导航（[userNavigationToken] 变化）或列表 detached，轮询立即终止，不会抢焦点。
+     */
+    fun restoreFocusAfterReturn(
+        retryTimes: Int = 6,
+        retryDelayMs: Long = 120L,
+        onRestored: () -> Unit = {},
+        onFailed: () -> Unit = {}
+    ) {
+        val anchor = capturedAnchor ?: currentAnchor ?: run {
+            logD("restoreFocusAfterReturn: no anchor, onFailed")
+            onFailed()
+            return
+        }
+        val position = resolveAnchorPosition(anchor)
+        if (position == RecyclerView.NO_POSITION || !adapter.isFocusablePosition(position)) {
+            logD("restoreFocusAfterReturn: pos=$position NOT focusable, onFailed")
+            onFailed()
+            return
+        }
+        // 立即强制恢复
+        restoreCapturedFocusPosition()
+        if (hasFocusInList()) {
+            logD("restoreFocusAfterReturn: restored immediately, pos=$position")
+            onRestored()
+            return
+        }
+        // 转场动画 / 布局未就绪：轮询重试
+        val token = userNavigationToken
+        var attempts = 0
+        val runnable = object : Runnable {
+            override fun run() {
+                if (token != userNavigationToken) {
+                    logD("restoreFocusAfterReturn: abort, user navigated")
+                    return
+                }
+                if (recyclerView.rootView == null || !recyclerView.isAttachedToWindow) {
+                    logD("restoreFocusAfterReturn: abort, not attached")
+                    return
+                }
+                attempts++
+                if (attempts > retryTimes) {
+                    logD("restoreFocusAfterReturn: retries exhausted, onFailed (pos=$position)")
+                    onFailed()
+                    return
+                }
+                if (hasFocusInList()) {
+                    logD("restoreFocusAfterReturn: restored on retry $attempts, pos=$position")
+                    onRestored()
+                    return
+                }
+                restoreCapturedFocusPosition()
+                recyclerView.postDelayed(this, retryDelayMs)
+            }
+        }
+        recyclerView.postDelayed(runnable, retryDelayMs)
+        logD("restoreFocusAfterReturn: scheduled retry, pos=$position")
+    }
+
     fun restoreCapturedAnchor(): Boolean {
         val anchor = capturedAnchor ?: currentAnchor ?: run {
             logD("restoreCapturedAnchor: no anchor, return false")
@@ -433,8 +505,11 @@ class TvListFocusController(
             return false
         }
         // 焦点已落在列表外部一个可见、可聚焦的 View 上（典型场景：侧边栏功能按钮），
-        // 说明用户正停留在侧边栏，不应把焦点拉回视频列表。从播放器返回的焦点恢复路径
-        // 走 MainActivity.restoreFocusAfterOverlayPop，不依赖此处，故跳过是安全的。
+        // 说明用户正停留在侧边栏，不应把焦点拉回视频列表。
+        // 注意：本"跳过外部焦点"仅适用于"用户主动聚焦侧边栏"的场景；"从播放器返回"时
+        // 焦点若停在返回按钮等外部控件上恰恰是需要拉回的，且此时并不走
+        // MainActivity.restoreFocusAfterOverlayPop（播放器是独立 Activity，返回走 finish()）。
+        // 播放器返回应改用 [restoreFocusAfterReturn]（强制拉回 + 轮询校验）。
         val focused = recyclerView.rootView?.findFocus()
         if (focused != null &&
             !isDescendantOf(focused, recyclerView) &&

--- a/app/src/main/java/com/tutu/myblbl/di/AppModule.kt
+++ b/app/src/main/java/com/tutu/myblbl/di/AppModule.kt
@@ -93,7 +93,7 @@ val viewModelModule = module {
     viewModel { HotViewModel(get(), get(), androidContext()) }
     viewModel { (type: Int) -> HomeLaneViewModel(type, get()) }
     viewModel { MainNavigationViewModel(get()) }
-    viewModel { VideoPlayerViewModel(get(), get(), get(), get(), get(), get(), get(named("noCookie")), androidContext(), get()) }
+    viewModel { VideoPlayerViewModel(get(), get(), get(), get(), get(), get(), get(named("noCookie")), get(), androidContext(), get()) }
     viewModel { CategoryViewModel(get()) }
     viewModel { DynamicViewModel(get()) }
     viewModel { LiveViewModel(get()) }

--- a/app/src/main/java/com/tutu/myblbl/feature/cctv/CctvLiveFragment.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/cctv/CctvLiveFragment.kt
@@ -132,11 +132,15 @@ class CctvLiveFragment : BaseFragment<FragmentCctvLiveBinding>(), MainTabFocusTa
             return
         }
         // 非重建场景（短时返回）：用控制器内存里的锚点还原进入播放器前的频道卡片。
-        val restored = tvFocusController?.restoreCapturedAnchor() == true
-        if (!restored) {
-            tvFocusController?.ensureValidFocus("resume", allowWhenFocusOutside = true)
-        }
-        Log.d(TAG, "onResume after restore restored=$restored focus=${describeFocus()}")
+        // 用 restoreFocusAfterReturn 强制拉回 + hasFocusInList 轮询，避免 restoreCapturedAnchor
+        // 因"焦点落在列表外部可见 View"而跳过、且返回值不可靠导致焦点丢失。
+        tvFocusController?.restoreFocusAfterReturn(
+            onRestored = {},
+            onFailed = {
+                tvFocusController?.ensureValidFocus("resume", allowWhenFocusOutside = true)
+            }
+        )
+        Log.d(TAG, "onResume after restore focus=${describeFocus()}")
         binding.recyclerView.postDelayed({
             if (!isAdded) return@postDelayed
             Log.d(TAG, "onResume settled@500ms focus=${describeFocus()}")

--- a/app/src/main/java/com/tutu/myblbl/feature/dynamic/DynamicFragment.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/dynamic/DynamicFragment.kt
@@ -549,7 +549,9 @@ class DynamicFragment : BaseFragment<FragmentDynamicBinding>(), MainTabFocusTarg
         videoFocusController?.requestFocusPosition(targetPosition)
     }
 
-    private fun scheduleVideoFocusRestore(retries: Int = 8) {
+    // 重试 16 次 × 48ms ≈ 768ms：真机大屏 Activity 转场动画可能 >400ms，
+    // 原 8 次(384ms) 窗口不足，易在动画期间耗尽重试导致焦点丢失。
+    private fun scheduleVideoFocusRestore(retries: Int = 16) {
         binding.recyclerViewRight.post {
             if (!isAdded || view == null) {
                 return@post

--- a/app/src/main/java/com/tutu/myblbl/feature/favorite/FavoriteDetailFragment.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/favorite/FavoriteDetailFragment.kt
@@ -41,6 +41,11 @@ class FavoriteDetailFragment : BaseFragment<FragmentFavoriteDetailBinding>() {
         private const val ARG_FOLDER_ID = "folder_id"
         private const val ARG_TITLE = "title"
 
+        // 从播放器返回后，焦点恢复到列表内的轮询参数：
+        // 覆盖 Activity 转场动画时长（真机大屏动画可能 >250ms），失败后兜底聚焦返回键。
+        private const val RESTORE_FOCUS_RETRY_TIMES = 6
+        private const val RESTORE_FOCUS_RETRY_DELAY_MS = 120L
+
         fun newInstance(folderId: Long, title: String): FavoriteDetailFragment {
             return FavoriteDetailFragment().apply {
                 arguments = bundleOf(
@@ -347,13 +352,65 @@ class FavoriteDetailFragment : BaseFragment<FragmentFavoriteDetailBinding>() {
         if (!isAdded) return
         binding.recyclerViewVideos.post {
             if (!isAdded) return@post
-            if (binding.recyclerViewVideos.isVisible && favoriteAdapter.itemCount > 0 && lastFocusedPosition != RecyclerView.NO_POSITION) {
-                val targetPosition = lastFocusedPosition.coerceIn(0, favoriteAdapter.itemCount - 1)
-                tvFocusController?.requestFocusPosition(targetPosition)
+            if (binding.recyclerViewVideos.isVisible && favoriteAdapter.itemCount > 0) {
+                val controller = tvFocusController
+                // 恢复优先级：
+                // ① 点击进入播放时捕获的锚点（capturedAnchor）——独立于 lastFocusedPosition，
+                //    不会被"返回按钮获得焦点"的监听器清空，是从播放器返回后恢复原视频最可靠的依据；
+                // ② 退而求其次用 lastFocusedPosition。
+                // 注意：返回时 buttonBack 的 setOnFocusChangeListener 会把 lastFocusedPosition
+                // 重置为 NO_POSITION，故不能单独依赖 lastFocusedPosition。
+                var restoreAction: (() -> Unit)? = null
+                if (controller != null && controller.hasCapturedAnchor()) {
+                    // 用强制恢复（restoreCapturedFocusPosition），不用 restoreCapturedAnchor：
+                    // 后者会在"焦点已落在返回按钮等列表外部 View"时跳过，导致焦点停在返回按钮。
+                    val c = controller
+                    restoreAction = { c.restoreCapturedFocusPosition() }
+                } else if (lastFocusedPosition != RecyclerView.NO_POSITION) {
+                    val target = lastFocusedPosition.coerceIn(0, favoriteAdapter.itemCount - 1)
+                    restoreAction = { controller?.requestFocusPosition(target) }
+                }
+                if (restoreAction != null) {
+                    restoreAction()
+                    retryRestoreFocus(restoreAction, retryLeft = RESTORE_FOCUS_RETRY_TIMES)
+                } else {
+                    requestBackFocus()
+                }
             } else {
                 requestBackFocus()
             }
         }
+    }
+
+    /**
+     * 轮询确认焦点是否已恢复到列表内。
+     *
+     * 背景：从播放器 `finish()` 返回时带 Activity 转场动画，`onResume` 里首次
+     * 恢复动作可能因 RecyclerView 子项尚未 attach / 未进入可见区
+     * （`RecyclerViewFocusOperator.requestAttachedPositionFocus` 的
+     * `isAttachedToWindow` / `isPartiallyVisible` 前置检查）而静默失败，且
+     * `requestFocusPosition` / `restoreCapturedAnchor` 返回值不可靠（内部失败也返回 true）。
+     * 真机（Android 7.1 电视盒子 + 红外遥控器）大屏转场动画耗时更长，250ms 重试窗口可能不足。
+     *
+     * 这里用 [hasFocusInList] 判断真实焦点落点：只要焦点回到列表内即视为恢复成功；
+     * 否则每 [RESTORE_FOCUS_RETRY_DELAY_MS] 重试一次 [restoreAction]，
+     * 重试耗尽仍无焦点则兜底聚焦返回键，避免焦点彻底消失。
+     */
+    private fun retryRestoreFocus(restoreAction: () -> Unit, retryLeft: Int) {
+        if (!isAdded) return
+        val controller = tvFocusController ?: return
+        if (controller.hasFocusInList()) {
+            return
+        }
+        if (retryLeft <= 0) {
+            requestBackFocus()
+            return
+        }
+        binding.recyclerViewVideos.postDelayed({
+            if (!isAdded) return@postDelayed
+            restoreAction()
+            retryRestoreFocus(restoreAction, retryLeft - 1)
+        }, RESTORE_FOCUS_RETRY_DELAY_MS)
     }
 
     private fun requestBackFocus() {

--- a/app/src/main/java/com/tutu/myblbl/feature/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/favorite/FavoriteFragment.kt
@@ -41,6 +41,10 @@ class FavoriteFragment : BaseFragment<FragmentFavoriteBinding>(), MeTabPage {
     companion object {
         private const val ARG_EMBEDDED = "embedded"
 
+        // 焦点恢复到列表内的轮询参数（覆盖转场动画窗口，失败后兜底返回键）
+        private const val RESTORE_FOCUS_RETRY_TIMES = 6
+        private const val RESTORE_FOCUS_RETRY_DELAY_MS = 120L
+
         fun newInstance() = FavoriteFragment()
 
         fun newEmbeddedInstance() = FavoriteFragment().apply {
@@ -415,11 +419,54 @@ class FavoriteFragment : BaseFragment<FragmentFavoriteBinding>(), MeTabPage {
                 .takeIf { it != RecyclerView.NO_POSITION }
                 ?.coerceIn(0, adapter.itemCount - 1)
                 ?: 0
-            val result = RecyclerViewFocusRestoreHelper.requestFocusAtPosition(
+            RecyclerViewFocusRestoreHelper.requestFocusAtPosition(
                 recyclerView = binding.recyclerViewFavorite,
                 position = targetPosition
             )
+            // 轮询确认真实焦点落点（转场动画/布局未就绪窗口），失败才兜底返回键，
+            // 避免 requestFocusAtPosition 返回值不可靠导致焦点彻底丢失。
+            retryRestoreFocus(targetPosition, retryLeft = RESTORE_FOCUS_RETRY_TIMES)
         }
+    }
+
+    /**
+     * 轮询确认真实焦点是否已恢复到收藏夹列表内。
+     *
+     * 背景：`RecyclerViewFocusRestoreHelper.requestFocusAtPosition` 在 holder 缺失时会
+     * `scrollToPosition` 后异步 `post` focusRequester，若此时 view 未布局 / touch mode /
+     * 转场动画期间，`requestFocus()` 可能失败且返回值不可靠。这里改用"焦点是否真正落在
+     * 列表内"作为成功判据，覆盖转场动画窗口，重试耗尽仍无焦点则兜底聚焦返回键。
+     */
+    private fun retryRestoreFocus(targetPosition: Int, retryLeft: Int) {
+        if (!isAdded) return
+        if (hasFocusInRecyclerView()) {
+            return
+        }
+        if (retryLeft <= 0) {
+            if (!embedded) {
+                requestBackFocus()
+            }
+            return
+        }
+        binding.recyclerViewFavorite.postDelayed({
+            if (!isAdded) return@postDelayed
+            RecyclerViewFocusRestoreHelper.requestFocusAtPosition(
+                recyclerView = binding.recyclerViewFavorite,
+                position = targetPosition
+            )
+            retryRestoreFocus(targetPosition, retryLeft - 1)
+        }, RESTORE_FOCUS_RETRY_DELAY_MS)
+    }
+
+    /** 当前真实焦点是否落在收藏夹列表 RecyclerView 内。 */
+    private fun hasFocusInRecyclerView(): Boolean {
+        val focused = binding.recyclerViewFavorite.rootView?.findFocus() ?: return false
+        var v: View? = focused
+        while (v != null) {
+            if (v === binding.recyclerViewFavorite) return true
+            v = v.parent as? View
+        }
+        return false
     }
 
     private fun requestBackFocus() {

--- a/app/src/main/java/com/tutu/myblbl/feature/live/LiveListFragment.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/live/LiveListFragment.kt
@@ -285,13 +285,23 @@ class LiveListFragment : BaseFragment<FragmentLiveListBinding>(), LiveTabPage {
 
     override fun onResume() {
         super.onResume()
-        tvFocusController?.restoreCapturedAnchor()
+        val controller = tvFocusController ?: return
+        // 从直播播放器返回：强制拉回捕获锚点 + 轮询确认真实焦点落点，避免焦点停在返回按钮
+        // 或彻底丢失（restoreCapturedAnchor 会因焦点落在列表外部 View 而跳过，且无兜底）。
+        controller.restoreFocusAfterReturn(
+            onRestored = {},
+            onFailed = { tvFocusController?.ensureValidFocus("resume") }
+        )
     }
 
     override fun onHiddenChanged(hidden: Boolean) {
         super.onHiddenChanged(hidden)
         if (!hidden) {
-            tvFocusController?.restoreCapturedAnchor()
+            val controller = tvFocusController ?: return
+            controller.restoreFocusAfterReturn(
+                onRestored = {},
+                onFailed = { tvFocusController?.ensureValidFocus("shown") }
+            )
         }
     }
 

--- a/app/src/main/java/com/tutu/myblbl/feature/live/LiveListFragment.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/live/LiveListFragment.kt
@@ -83,7 +83,12 @@ class LiveListFragment : BaseFragment<FragmentLiveListBinding>(), LiveTabPage {
     }
 
     override fun initView() {
-        adapter = LiveRoomAdapter(onItemClick = ::onRoomClick)
+        adapter = LiveRoomAdapter(
+            onItemClick = ::onRoomClick,
+            onDpadKey = { view, keyCode, event ->
+                tvFocusController?.handleKey(view, keyCode, event) ?: false
+            }
+        )
 
         val layoutManager = WrapContentGridLayoutManager(requireContext(), 4)
         binding.recyclerView.layoutManager = layoutManager

--- a/app/src/main/java/com/tutu/myblbl/feature/live/LiveRoomAdapter.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/live/LiveRoomAdapter.kt
@@ -24,7 +24,8 @@ import java.util.concurrent.atomic.AtomicInteger
 
 class LiveRoomAdapter(
     private val onItemClick: (LiveRoomItem) -> Unit,
-    private val onTopEdgeUp: (() -> Boolean)? = null
+    private val onTopEdgeUp: (() -> Boolean)? = null,
+    private val onDpadKey: ((View, Int, KeyEvent) -> Boolean)? = null
 ) : RecyclerView.Adapter<LiveRoomAdapter.ViewHolder>(), TvFocusableAdapter {
 
     private val items = ArrayList<LiveRoomItem>()
@@ -99,7 +100,7 @@ class LiveRoomAdapter(
         private val longPressThreshold = 5_000L
         private var longPressTriggered = false
 
-        private val keyListener = View.OnKeyListener { _, keyCode, event ->
+        private val keyListener = View.OnKeyListener { view, keyCode, event ->
             if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_ENTER) {
                 when (event.action) {
                     KeyEvent.ACTION_DOWN -> {
@@ -112,7 +113,9 @@ class LiveRoomAdapter(
                     }
                 }
             }
-            false
+            // 把 DPAD 方向键交给网格焦点控制器（GridTvFocusStrategy），
+            // 保证严格按“下一行同列”跳格，避免退化为 FocusFinder 的空间查找导致跳行不稳定。
+            onDpadKey?.invoke(view, keyCode, event) ?: false
         }
 
         private fun startLongPressTimer() {
@@ -164,6 +167,7 @@ class LiveRoomAdapter(
             VideoCardFocusHelper.bindSidebarExit(
                 view = views.root,
                 onTopEdgeUp = onTopEdgeUp,
+                handleListDpadDown = false,
                 chainedListener = keyListener
             )
         }

--- a/app/src/main/java/com/tutu/myblbl/feature/marmot/web/MarmotWebViewClient.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/marmot/web/MarmotWebViewClient.kt
@@ -207,7 +207,8 @@ class MarmotSystemWebViewClient(
 
     /** 判断图片是否允许加载（对标参考 `imageLoad`）。 */
     private fun isImageAllowed(url: String): Boolean {
-        return url.contains("tvImg") || url.contains("cctvpic.com") || url.contains("default")
+        return url.contains("tvImg") || url.contains("cctvpic.com") ||
+            url.contains("player.cntv.cn") || url.contains("default")
     }
 
     private fun httpGetStream(url: String): InputStream? = try {

--- a/app/src/main/java/com/tutu/myblbl/feature/marmot/web/MarmotWebViewClient.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/marmot/web/MarmotWebViewClient.kt
@@ -89,8 +89,14 @@ class MarmotSystemWebViewClient(
             Log.w(TAG, "tv.user.js 为空，跳过注入")
             return
         }
-        view.evaluateJavascript(script, null)
-        Log.i(TAG, "已注入 tv.user.js（${script.length} 字符）到 $url")
+        // 关键：把 _tvState.platform 占位符 "//platform//" 替换为 "android"。
+        // 否则 platform 保持占位符，tv.user.js 会用 marmot://res.vonchange.com 加载本地脚本，
+        // 而部分官网（如 tv.gxtv.cn）带 CSP（default-src *）会拒绝 marmot:// 自定义 scheme，
+        // 导致 common.js/detail.js 加载失败、全屏劫持不生效。替换后改用官网 https 域名加载，
+        // scheme 为 https 且 URL 含 tv-web，会被 shouldInterceptRequest 拦截返回本地资源。
+        val finalScript = script.replace("//platform//", "android")
+        view.evaluateJavascript(finalScript, null)
+        Log.i(TAG, "已注入 tv.user.js（${finalScript.length} 字符）到 $url")
     }
 
     override fun onReceivedSslError(view: WebView?, handler: SslErrorHandler?, error: SslError?) {

--- a/app/src/main/java/com/tutu/myblbl/feature/marmot/web/MarmotX5WebViewClient.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/marmot/web/MarmotX5WebViewClient.kt
@@ -170,7 +170,8 @@ class MarmotX5WebViewClient(
     }
 
     private fun isImageAllowed(url: String): Boolean =
-        url.contains("tvImg") || url.contains("cctvpic.com") || url.contains("default")
+        url.contains("tvImg") || url.contains("cctvpic.com") ||
+            url.contains("player.cntv.cn") || url.contains("default")
 
     private fun httpGetStream(url: String): InputStream? = try {
         client.newCall(Request.Builder().url(url).get().build()).execute().body?.byteStream()

--- a/app/src/main/java/com/tutu/myblbl/feature/marmot/web/MarmotX5WebViewClient.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/marmot/web/MarmotX5WebViewClient.kt
@@ -69,8 +69,14 @@ class MarmotX5WebViewClient(
             Log.w(TAG, "tv.user.js 为空，跳过注入")
             return
         }
-        view.evaluateJavascript(script, null)
-        Log.i(TAG, "已注入 tv.user.js（${script.length} 字符）到 $url")
+        // 关键：把 _tvState.platform 占位符 "//platform//" 替换为 "android"。
+        // 否则 platform 保持占位符，tv.user.js 会用 marmot://res.vonchange.com 加载本地脚本，
+        // 而部分官网（如 tv.gxtv.cn）带 CSP（default-src *）会拒绝 marmot:// 自定义 scheme，
+        // 导致 common.js/detail.js 加载失败、全屏劫持不生效。替换后改用官网 https 域名加载，
+        // scheme 为 https 且 URL 含 tv-web，会被 shouldInterceptRequest 拦截返回本地资源。
+        val finalScript = script.replace("//platform//", "android")
+        view.evaluateJavascript(finalScript, null)
+        Log.i(TAG, "已注入 tv.user.js（${finalScript.length} 字符）到 $url")
     }
 
     override fun onReceivedSslError(view: WebView?, handler: SslErrorHandler?, error: SslError?) {

--- a/app/src/main/java/com/tutu/myblbl/feature/marmot/web/WebEngine.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/marmot/web/WebEngine.kt
@@ -89,6 +89,17 @@ class WebEngine(
         }
     }
 
+    /** 执行 JS 并回调结果（result 为字符串，可能带引号转义）。系统/X5 共用。 */
+    fun evaluateJavascriptWithResult(js: String, callback: (result: String) -> Unit) {
+        if (usingX5) {
+            (view as com.tencent.smtt.sdk.WebView)
+                .evaluateJavascript(js) { value -> callback(value ?: "") }
+        } else {
+            (view as android.webkit.WebView)
+                .evaluateJavascript(js) { value -> callback(value ?: "") }
+        }
+    }
+
     fun onPause() {
         if (usingX5) runCatching { (view as com.tencent.smtt.sdk.WebView).onPause() }
         else runCatching { (view as android.webkit.WebView).onPause() }
@@ -278,6 +289,10 @@ class WebEngine(
             com.tutu.myblbl.core.common.log.AppLog.d(TAG, msg)
             return true
         }
+        override fun onProgressChanged(view: android.webkit.WebView?, newProgress: Int) {
+            // 上报真实加载进度（1-99），驱动遮罩上的"正在加载网页 x%"文字
+            onProgress(newProgress)
+        }
         override fun onShowCustomView(view: android.view.View, callback: android.webkit.WebChromeClient.CustomViewCallback) {
             Log.i(TAG, "系统 onShowCustomView")
             onShowCustomView.invoke(view)
@@ -298,6 +313,10 @@ class WebEngine(
             Log.d(TAG, msg)
             com.tutu.myblbl.core.common.log.AppLog.d(TAG, msg)
             return true
+        }
+        override fun onProgressChanged(view: com.tencent.smtt.sdk.WebView?, newProgress: Int) {
+            // 上报真实加载进度（1-99），驱动遮罩上的"正在加载网页 x%"文字
+            onProgress(newProgress)
         }
         override fun onShowCustomView(view: android.view.View, callback: com.tencent.smtt.export.external.interfaces.IX5WebChromeClient.CustomViewCallback) {
             Log.i(TAG, "X5 onShowCustomView")

--- a/app/src/main/java/com/tutu/myblbl/feature/me/MeListFragment.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/me/MeListFragment.kt
@@ -51,6 +51,10 @@ class MeListFragment : BaseFragment<FragmentMeTabListBinding>(), MeTabPage, com.
         const val TYPE_LATER = "later"
         private const val CACHE_TTL_MS = 10 * 60 * 1000L
 
+        // 历史列表焦点恢复到列表内的轮询参数（覆盖转场动画窗口，失败兜底首个内容）
+        private const val RESTORE_FOCUS_RETRY_TIMES = 6
+        private const val RESTORE_FOCUS_RETRY_DELAY_MS = 120L
+
         private const val ARG_TYPE = "type"
 
         fun newInstance(type: String): MeListFragment {
@@ -864,11 +868,13 @@ class MeListFragment : BaseFragment<FragmentMeTabListBinding>(), MeTabPage, com.
                         .takeIf { it != RecyclerView.NO_POSITION }
                         ?.coerceIn(0, adapter.itemCount - 1)
                     ?: 0
-                val handled = tvFocusController?.requestFocusPosition(targetPosition) == true ||
+                tvFocusController?.requestFocusPosition(targetPosition) == true ||
                     requestVisibleHistoryFocus(targetPosition)
                 binding.recyclerView.post {
                     restoreHistoryViewportAnchor()
                 }
+                // 轮询确认真实焦点落点（转场动画/布局未就绪窗口），失败兜底首个内容
+                retryHistoryRestoreFocus(targetPosition, retryLeft = RESTORE_FOCUS_RETRY_TIMES)
             } else {
                 if (tvFocusController?.restoreCapturedAnchor() != true &&
                     tvFocusController?.focusPrimary() != true
@@ -924,6 +930,43 @@ class MeListFragment : BaseFragment<FragmentMeTabListBinding>(), MeTabPage, com.
         }
         binding.recyclerView.post {
             requestVisibleHistoryFocus(position, retries - 1)
+        }
+        return false
+    }
+
+    /**
+     * 轮询确认真实焦点是否已恢复到历史列表内。
+     *
+     * 背景：`requestVisibleHistoryFocus` 以 `requestFocus() == true` 判断成功，但 `requestFocus`
+     * 在 touch mode / view 未 attach / 转场动画期间可能返回 false 且返回值不可靠，重试耗尽后
+     * 静默放弃。这里改用"焦点是否真正落在列表内"作为成功判据，覆盖转场动画窗口，失败兜底首个内容。
+     */
+    private fun retryHistoryRestoreFocus(targetPosition: Int, retryLeft: Int) {
+        if (!isAdded) return
+        if (hasFocusInHistoryRecyclerView()) {
+            return
+        }
+        if (retryLeft <= 0) {
+            focusPrimaryContent()
+            return
+        }
+        binding.recyclerView.postDelayed({
+            if (!isAdded) return@postDelayed
+            val holder = binding.recyclerView.findViewHolderForAdapterPosition(targetPosition)
+            if (holder?.itemView?.requestFocus() != true) {
+                tvFocusController?.requestFocusPosition(targetPosition)
+            }
+            retryHistoryRestoreFocus(targetPosition, retryLeft - 1)
+        }, RESTORE_FOCUS_RETRY_DELAY_MS)
+    }
+
+    /** 当前真实焦点是否落在历史列表 RecyclerView 内。 */
+    private fun hasFocusInHistoryRecyclerView(): Boolean {
+        val focused = binding.recyclerView.rootView?.findFocus() ?: return false
+        var v: View? = focused
+        while (v != null) {
+            if (v === binding.recyclerView) return true
+            v = v.parent as? View
         }
         return false
     }

--- a/app/src/main/java/com/tutu/myblbl/feature/player/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/player/VideoPlayerViewModel.kt
@@ -2153,7 +2153,7 @@ class VideoPlayerViewModel(
         if (!userRepository.isLoggedIn()) return null
 
         val resumeStartMs = System.currentTimeMillis()
-        val maxPages = 3
+        val maxPages = 6
         val pageSize = 30
         var viewAt = 0L
         val matchedAid = aid?.takeIf { it > 0L }

--- a/app/src/main/java/com/tutu/myblbl/feature/player/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/player/VideoPlayerViewModel.kt
@@ -42,11 +42,13 @@ import com.tutu.myblbl.core.common.log.AppLog
 import com.tutu.myblbl.core.common.settings.AppSettingsDataStore
 import com.tutu.myblbl.feature.player.cache.PlayerMediaCache
 import com.tutu.myblbl.network.cookie.CookieManager
+import com.tutu.myblbl.repository.UserRepository
 import com.tutu.myblbl.feature.player.settings.PlayerSettings
 import com.tutu.myblbl.feature.player.settings.PlayerSettingsStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
@@ -70,6 +72,7 @@ class VideoPlayerViewModel(
     private val securityGateway: NetworkSecurityGateway,
     private val appSettings: AppSettingsDataStore,
     private val noCookieApiService: ApiService,
+    private val userRepository: UserRepository,
     context: Context,
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
@@ -2025,13 +2028,42 @@ class VideoPlayerViewModel(
 
         val episodeItems = episodeCatalogBuilder.buildUgcEpisodes(detail)
         _episodes.value = episodeItems
+
         // 分P 选择：优先按 cid 精确匹配。
         // 注意：不能加 bvid 匹配作为 fallback——多P视频所有分P共用同一个 bvid，
         // 会导致 indexOfFirst 永远命中第一个分P，覆盖掉调用方传入的目标 cid（公益广告场景踩到）。
-        val selectedIndex = if (currentCid > 0L) {
+        var selectedIndex = if (currentCid > 0L) {
             episodeItems.indexOfFirst { it.cid == currentCid }.takeIf { it >= 0 } ?: 0
         } else {
             0
+        }
+
+        // ── 续播定位：当前未指定 cid（如收藏夹入口）时，先查历史记录接口定位最后播放分P，
+        // 未命中再降级为遍历探测（用所有分P cid 并发请求 playurl，取 last_play_time 最大的分P）。
+        // 历史接口一次请求即可拿全「最后观看分P + 进度」，优于遍历探测的 O(N) 次 playurl 请求。
+        if (currentCid <= 0L && episodeItems.size > 1) {
+            val historyResume = resolveResumeFromHistory(episodeItems)
+            if (historyResume != null) {
+                val (historyIndex, historyProgressMs) = historyResume
+                AppLog.i(
+                    TAG,
+                    "history_resume applied: index=$historyIndex cid=${episodeItems[historyIndex].cid} " +
+                        "progressMs=$historyProgressMs"
+                )
+                selectedIndex = historyIndex
+                if (historyProgressMs > 0L) {
+                    pendingSeekPositionMs = historyProgressMs
+                }
+            } else {
+                val probeResult = probeLastPlayEpisode(episodeItems)
+                if (probeResult != null) {
+                    val (probeIndex, probeTime) = probeResult
+                    AppLog.i(TAG, "probe_resume found: index=$probeIndex cid=${episodeItems[probeIndex].cid} lastPlayTime=${probeTime}ms")
+                    selectedIndex = probeIndex
+                } else {
+                    AppLog.i(TAG, "probe_resume not_found: no episode has last_play_time > 5000ms")
+                }
+            }
         }
         _selectedEpisodeIndex.value = selectedIndex
         val selectedEpisode = episodeItems.getOrNull(selectedIndex)
@@ -2094,6 +2126,143 @@ class VideoPlayerViewModel(
                 }
             }
         }
+    }
+
+    /**
+     * 先查历史记录接口定位用户最后播放的分P。
+     *
+     * 为什么优先历史接口而非遍历 playurl：历史接口 `x/web-interface/history/cursor` 一次请求
+     * 就能同时拿到「最后观看分P（history.cid）」与「进度（progress）」，而遍历 playurl 需要对
+     * 全部分P逐个请求（125P 最坏 25 批、5 秒），服务端压力与首屏延迟都明显更大。
+     *
+     * 匹配方式：历史记录列表从新到旧，用 aid/bvid 匹配目标视频，命中即用其 history.cid 定位分P。
+     * `history.cid` 即用户最后观看的分P cid（语义最准，而非遍历法的 last_play_time 间接推断）。
+     *
+     * 分页策略：ps 上限 30，最多翻 3 页（90 条）。翻 3 页仍未命中则放弃（用户最近 90 条观看记录
+     * 中都没有该视频，说明很久没看，继续翻页收益低、代价大），降级到遍历探测兜底。
+     *
+     * @param episodes 分P列表（用于把 history.cid 映射为分P索引）
+     * @return Pair<分P索引, 进度毫秒>，未命中返回 null。
+     */
+    private suspend fun resolveResumeFromHistory(
+        episodes: List<PlayableEpisode>
+    ): Pair<Int, Long>? {
+        val aid = currentAid
+        val bvid = currentBvid?.takeIf { it.isNotBlank() }
+        if ((aid == null || aid <= 0L) && bvid.isNullOrBlank()) return null
+        if (!userRepository.isLoggedIn()) return null
+
+        val resumeStartMs = System.currentTimeMillis()
+        val maxPages = 3
+        val pageSize = 30
+        var viewAt = 0L
+        val matchedAid = aid?.takeIf { it > 0L }
+        val matchedBvid = bvid
+
+        for (page in 1..maxPages) {
+            val result = userRepository.getHistory(viewAt, pageSize).getOrNull()
+            val history = result?.data ?: return null
+            val list = history.list
+            if (list.isEmpty()) break
+
+            for (item in list) {
+                val itemAid = item.history?.oid ?: item.kid
+                val itemBvid = item.history?.bvid?.ifEmpty { item.bvid } ?: item.bvid
+                val isMatch = (matchedAid != null && itemAid == matchedAid) ||
+                    (matchedBvid != null && itemBvid == matchedBvid)
+                if (!isMatch) continue
+
+                val resumeCid = item.history?.cid
+                if (resumeCid == null || resumeCid <= 0L) continue
+                val episodeIndex = episodes.indexOfFirst { it.cid == resumeCid }
+                if (episodeIndex < 0) continue
+
+                // progress 字段单位是「秒」，转成毫秒与播放器进度对齐
+                val resumeMs = (item.progress.takeIf { it > 0L } ?: 0L) * 1000L
+                val durationMs = System.currentTimeMillis() - resumeStartMs
+                AppLog.i(
+                    TAG,
+                    "history_resume hit: page=$page index=$episodeIndex cid=$resumeCid " +
+                        "progressMs=$resumeMs durationMs=$durationMs"
+                )
+                return episodeIndex to resumeMs
+            }
+
+            viewAt = history.cursor?.viewAt
+                ?: list.lastOrNull()?.viewAt
+                ?: 0L
+            if (viewAt <= 0L) break
+        }
+
+        val durationMs = System.currentTimeMillis() - resumeStartMs
+        AppLog.i(TAG, "history_resume not_found: pages=$maxPages durationMs=$durationMs")
+        return null
+    }
+
+    /**
+     * 从前往后分批探测用户最后播放的分P。
+     *
+     * 为什么不用二分：实测数据显示 playurl 的 last_play_time 在分P列表中呈极度稀疏分布
+     * （125P 中仅 1 个分P有记录），二分采样命中率约 2%，几乎必定退化到全量扫描。
+     *
+     * 为什么从前往后：用户从第1P开始看，看到哪里停在哪里。从前往后按播放顺序找到
+     * 第一个（也是唯一）有播放记录的分P即停止。
+     *
+     * 策略：从第0P开始，每批并发 5 个请求，批次内从后往前取最后一个 last_play_time > 5000ms 的分P。
+     * 命中即停止，未命中继续下一批。最坏情况扫描全量。
+     *
+     * @return Pair<分P索引, last_play_time毫秒>，若所有分P均无播放记录则返回 null。
+     */
+    private suspend fun probeLastPlayEpisode(
+        episodes: List<PlayableEpisode>
+    ): Pair<Int, Long>? = coroutineScope {
+        if (episodes.isEmpty()) return@coroutineScope null
+
+        val aid = currentAid
+        val bvid = currentBvid?.takeIf { it.isNotBlank() }
+        if ((aid == null || aid <= 0L) && bvid.isNullOrBlank()) return@coroutineScope null
+
+        val qualityId = requestedQualityId ?: selectedQualityId ?: 80
+        val fnval = 16
+        val fourk = 0
+        val batchSize = 5
+        val probeStartMs = System.currentTimeMillis()
+
+        suspend fun queryEpisode(index: Int): Pair<Int, Long> {
+            val ep = episodes[index]
+            val result = playInfoGateway.requestPlayInfo(
+                aid = aid, bvid = bvid, cid = ep.cid,
+                epId = null, qualityId = qualityId,
+                fnval = fnval, fourk = fourk,
+                allowWbi = true, seasonId = 0L
+            )
+            val lastPlayTime = result?.data?.lastPlayTime ?: 0L
+            AppLog.d(TAG, "probe_resume episode[$index] cid=${ep.cid} lastPlayTime=${lastPlayTime}ms")
+            return index to lastPlayTime
+        }
+
+        // 从前往后分批探测
+        var offset = 0
+        while (offset < episodes.size) {
+            val end = minOf(offset + batchSize - 1, episodes.size - 1)
+            val batchIndices = (offset..end).toList()
+            val batchResults = batchIndices.map { idx -> async { queryEpisode(idx) } }.awaitAll()
+
+            // 在批次内从后往前找最后一个有效的
+            val hit = batchResults.lastOrNull { it.second > 5000L }
+            if (hit != null) {
+                val probeDurationMs = System.currentTimeMillis() - probeStartMs
+                val batchesDone = (offset / batchSize) + 1
+                AppLog.i(TAG, "probe_resume hit: index=${hit.first} lastPlayTime=${hit.second}ms durationMs=$probeDurationMs batches=$batchesDone")
+                return@coroutineScope hit.first to hit.second
+            }
+
+            offset = end + 1
+        }
+
+        val probeDurationMs = System.currentTimeMillis() - probeStartMs
+        AppLog.i(TAG, "probe_resume not_found: episodes=${episodes.size} durationMs=$probeDurationMs")
+        return@coroutineScope null
     }
 
     private fun canReusePreparedPlayback(

--- a/app/src/main/java/com/tutu/myblbl/feature/player/danmaku/DanmakuTimer.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/player/danmaku/DanmakuTimer.kt
@@ -1,6 +1,7 @@
 package com.tutu.myblbl.feature.player.danmaku
 
 import kotlin.math.abs
+import kotlin.math.exp
 
 /**
  * AkDanmaku-style timer:
@@ -64,33 +65,33 @@ internal class DanmakuTimer {
         }
 
         val dtNanos = (nowNanos - lastNanos).coerceAtLeast(0L)
+        val dtMs = dtNanos.toDouble() / 1_000_000.0
         lastFrameNanos = nowNanos
         lastSeekSerial = seekSerial
 
         if (!isPlaying) {
-            // 暂停/恢复瞬间 ExoPlayer 的 raw position 常会回退几十~上百毫秒
-            // （解码器缓冲固有行为）。若此时无条件重锚到 raw，弹幕会瞬间"时间倒流"。
-            // 修复：暂停瞬间保留当前平滑位置不动；暂停中也只允许往前纠偏，禁止回退。
-            if (lastPlaying) {
-                // 刚从播放切到暂停：保持弹幕停在当前平滑位置，绝不回退。
-            } else if (raw - smoothPositionMs >= IDLE_REANCHOR_THRESHOLD_MS) {
-                // 暂停中，raw 明显往前跳（如 seek 到更晚位置），才向前重锚。
-                smoothPositionMs = raw
+            // 暂停/缓冲：保留当前平滑位置不动；仅当 raw 明显往前跳（如 seek 到更晚位置）才向前收敛。
+            // 注意：缓冲期间 ExoPlayer 的 currentPosition 可能已按解码时间前进，但这里不追，
+            // 等恢复播放时再由下方恢复分支渐进追上，避免缓冲中弹幕乱跳。
+            if (!lastPlaying && raw - smoothPositionMs >= IDLE_REANCHOR_THRESHOLD_MS) {
+                smoothPositionMs = convergeTo(raw, dtMs)
             }
             lastPlaying = false
             lastPlaybackSpeed = speed
             return smoothPositionMs.toLong()
         }
 
+        // 从暂停/缓冲恢复，或倍速变化：不再把平滑位置一次性硬锚到 raw，而是渐进收敛。
+        // 这是"所有字幕统一大跳"的根因所在——缓冲期间弹幕停在原地，恢复瞬间 raw 已领先
+        // 较多，硬锚会让每一条弹幕在同一帧整体前移 `(raw - smoothPositionMs) * pxPerMs`。
         if (!lastPlaying || abs(speed - lastPlaybackSpeed) >= SPEED_CHANGE_EPSILON) {
-            smoothPositionMs = raw
             lastPlaying = true
             lastPlaybackSpeed = speed
+            smoothPositionMs = convergeTo(raw, dtMs)
             return smoothPositionMs.toLong()
         }
 
         if (dtNanos > 0L) {
-            val dtMs = dtNanos.toDouble() / 1_000_000.0
             smoothPositionMs += dtMs * speed
         }
 
@@ -100,12 +101,26 @@ internal class DanmakuTimer {
         }
         if (smoothPositionMs < 0.0) smoothPositionMs = 0.0
         if (abs(raw - smoothPositionMs) >= EXTREME_DRIFT_REANCHOR_THRESHOLD_MS) {
-            // Treat this as an unreported discontinuity instead of gradually bending speed.
-            smoothPositionMs = raw
+            // 未报告的极端漂移：渐进收敛而非瞬间拉回，避免肉眼可见的整体跳变。
+            // 收敛期间该分支每帧都会再次命中，convergeTo 幂等，效果为持续的加速追赶。
+            smoothPositionMs = convergeTo(raw, dtMs)
         }
         lastPlaying = true
         lastPlaybackSpeed = speed
         return smoothPositionMs.toLong()
+    }
+
+    /**
+     * 将平滑位置向目标 target 渐进收敛，避免把播放器位置 raw 的一次性硬锚放大成
+     * "所有弹幕统一大跳"。以指数衰减速率收敛，时间常数 [CATCH_UP_TIME_CONSTANT_MS]
+     * 控制追赶快慢（越小追得越快）；偏差小于 [CATCH_UP_TOLERANCE_MS] 时直接吸合。
+     */
+    private fun convergeTo(target: Double, deltaMs: Double): Double {
+        val diff = target - smoothPositionMs
+        if (!diff.isFinite()) return target
+        if (abs(diff) <= CATCH_UP_TOLERANCE_MS) return target
+        val rate = 1.0 - exp(-deltaMs.coerceAtLeast(0.0) / CATCH_UP_TIME_CONSTANT_MS)
+        return smoothPositionMs + diff * rate
     }
 
     private fun normalizeSpeed(playbackSpeed: Float): Double =
@@ -118,5 +133,11 @@ internal class DanmakuTimer {
         private const val IDLE_REANCHOR_THRESHOLD_MS = 120.0
         private const val EXTREME_DRIFT_REANCHOR_THRESHOLD_MS = 2_000.0
         private const val SPEED_CHANGE_EPSILON = 0.0001
+
+        // 平滑位置向播放器位置收敛的参数：偏差小于该值直接吸合（肉眼看不出跳变）。
+        private const val CATCH_UP_TOLERANCE_MS = 30.0
+        // 收敛时间常数（ms）：偏差越大追赶越久，但保持"短暂加速追上"而非"瞬间跳变"。
+        // 300ms 时：1 帧(~16ms)收敛约 5%，300ms 收敛约 63%，1s 收敛约 96%。
+        private const val CATCH_UP_TIME_CONSTANT_MS = 300.0
     }
 }

--- a/app/src/main/java/com/tutu/myblbl/feature/player/view/MyPlayerSettingView.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/player/view/MyPlayerSettingView.kt
@@ -930,7 +930,7 @@ class MyPlayerSettingView @JvmOverloads constructor(
             .setListener(object : AnimatorListenerAdapter() {
                 override fun onAnimationEnd(animation: Animator) {
                     recyclerView.animate().setListener(null)
-                    applyMenuRows(menuKey, rows, requestFocusAfter = false, focusPosition = focusPosition)
+                    applyMenuRows(menuKey, rows, focusPosition = focusPosition)
                     recyclerView.alpha = 0f
                     recyclerView.animate()
                         .alpha(1f)
@@ -938,7 +938,6 @@ class MyPlayerSettingView @JvmOverloads constructor(
                         .setListener(object : AnimatorListenerAdapter() {
                             override fun onAnimationEnd(animation: Animator) {
                                 recyclerView.animate().setListener(null)
-                                requestMenuFocus(focusPosition)
                             }
                         })
                         .start()
@@ -954,8 +953,13 @@ class MyPlayerSettingView @JvmOverloads constructor(
         focusPosition: Int = 1
     ) {
         if (requestFocusAfter) {
+            // Clear any existing focus before submitting so the system does not auto-focus the
+            // first visible item during the relayout (which would cause a visible focus "jump"
+            // before we explicitly place focus on the intended item).
+            recyclerView.clearFocus()
             adapter.submitRows(menuKey, rows) {
-                recyclerView.scrollToPosition(0)
+                // Scroll directly to the focus target so its view is laid out before we request focus.
+                recyclerView.scrollToPosition(focusPosition)
                 requestMenuFocus(focusPosition)
             }
         } else {
@@ -987,7 +991,19 @@ class MyPlayerSettingView @JvmOverloads constructor(
             if (targetView?.isFocusable == true) {
                 targetView.requestFocus()
             } else {
-                recyclerView.requestFocus()
+                // Target not laid out yet; scroll to it then retry, instead of falling back to
+                // recyclerView.requestFocus() (which lets the system focus the first visible item).
+                recyclerView.scrollToPosition(pos)
+                recyclerView.post {
+                    val retryView = recyclerView.findViewHolderForAdapterPosition(pos)?.itemView
+                        ?: recyclerView.layoutManager?.findViewByPosition(pos)
+                    if (retryView?.isFocusable == true) {
+                        retryView.requestFocus()
+                    } else {
+                        recyclerView.requestFocus()
+                    }
+                    logSettingFocus("  retry: pos=$pos retryView=$retryView focusAfter=${findFocus()}")
+                }
             }
             logSettingFocus("  post: focusAfter=${findFocus()}")
         }

--- a/app/src/main/java/com/tutu/myblbl/feature/player/view/MyPlayerSettingView.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/player/view/MyPlayerSettingView.kt
@@ -691,7 +691,10 @@ class MyPlayerSettingView @JvmOverloads constructor(
     }
 
     private fun showPlaybackSpeedMenu() {
-        showSubMenu(ITEM_PLAYBACK_SPEED, menuBuilder.buildPlaybackSpeedMenu(panelState))
+        val speedIndex = PLAYBACK_SPEEDS.indexOfFirst { it == panelState.currentSpeed }
+        val focusPosition = if (speedIndex >= 0) speedIndex + 1 else 1 // +1 to skip Header row
+        logSettingFocus("showPlaybackSpeedMenu speed=${panelState.currentSpeed} speedIndex=$speedIndex focusPosition=$focusPosition")
+        showSubMenu(ITEM_PLAYBACK_SPEED, menuBuilder.buildPlaybackSpeedMenu(panelState), focusPosition = focusPosition)
     }
 
     private fun showSubtitles() {
@@ -733,18 +736,15 @@ class MyPlayerSettingView @JvmOverloads constructor(
         )
     }
 
-    private fun showSubMenu(menuKey: Int, rows: List<PlayerSettingRow>) {
-        showSubMenu(menuKey, rows, animateTransition = true)
-    }
-
     private fun showSubMenu(
         menuKey: Int,
         rows: List<PlayerSettingRow>,
-        animateTransition: Boolean
+        animateTransition: Boolean = true,
+        focusPosition: Int = 1
     ) {
         menuLevel = LEVEL_SUB
         updateBackIcon()
-        submitMenuRows(menuKey = menuKey, rows = rows, animateTransition = animateTransition)
+        submitMenuRows(menuKey = menuKey, rows = rows, animateTransition = animateTransition, focusPosition = focusPosition)
     }
 
     private fun goBackToMainMenu() {

--- a/app/src/main/java/com/tutu/myblbl/feature/player/view/MyPlayerSettingView.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/player/view/MyPlayerSettingView.kt
@@ -388,7 +388,7 @@ class MyPlayerSettingView @JvmOverloads constructor(
     }
 
     private fun showLiveQualitySubMenu() {
-        showSubMenu(ITEM_LIVE_QUALITY, menuBuilder.buildLiveQualityMenu(panelState))
+        showSubMenu(ITEM_LIVE_QUALITY, menuBuilder.buildLiveQualityMenu(panelState), focusPosition = liveQualityFocusPosition())
     }
 
     fun setLiveLines(lines: List<LiveLineInfo>, selectedIndex: Int) {
@@ -430,8 +430,15 @@ class MyPlayerSettingView @JvmOverloads constructor(
     }
 
     private fun showLiveLineSubMenu() {
-        showSubMenu(ITEM_LIVE_LINE, menuBuilder.buildLiveLineMenu(panelState))
+        showSubMenu(ITEM_LIVE_LINE, menuBuilder.buildLiveLineMenu(panelState), focusPosition = liveLineFocusPosition())
     }
+
+    private fun liveQualityFocusPosition(): Int =
+        panelState.liveQualities
+            .indexOfFirst { it.qn == panelState.currentLiveQualityQn }
+            .let { if (it >= 0) it + 1 else 1 }
+
+    private fun liveLineFocusPosition(): Int = panelState.currentLiveLineIndex + 1
 
     fun dmEnableClick() {
         updateState { it.copy(dmEnabled = !it.dmEnabled) }
@@ -687,38 +694,69 @@ class MyPlayerSettingView @JvmOverloads constructor(
     }
 
     private fun showVideoQualityMenu() {
-        showSubMenu(ITEM_VIDEO_QUALITY, menuBuilder.buildVideoQualityMenu(panelState))
+        showSubMenu(ITEM_VIDEO_QUALITY, menuBuilder.buildVideoQualityMenu(panelState), focusPosition = videoQualityFocusPosition())
     }
 
     private fun showPlaybackSpeedMenu() {
-        val speedIndex = PLAYBACK_SPEEDS.indexOfFirst { it == panelState.currentSpeed }
-        val focusPosition = if (speedIndex >= 0) speedIndex + 1 else 1 // +1 to skip Header row
-        logSettingFocus("showPlaybackSpeedMenu speed=${panelState.currentSpeed} speedIndex=$speedIndex focusPosition=$focusPosition")
-        showSubMenu(ITEM_PLAYBACK_SPEED, menuBuilder.buildPlaybackSpeedMenu(panelState), focusPosition = focusPosition)
+        showSubMenu(ITEM_PLAYBACK_SPEED, menuBuilder.buildPlaybackSpeedMenu(panelState), focusPosition = playbackSpeedFocusPosition())
     }
 
     private fun showSubtitles() {
         if (panelState.subtitles.isEmpty()) {
             return
         }
-        showSubMenu(ITEM_SUBTITLE, menuBuilder.buildSubtitleMenu(panelState))
+        showSubMenu(ITEM_SUBTITLE, menuBuilder.buildSubtitleMenu(panelState), focusPosition = subtitleFocusPosition())
     }
 
     private fun showVideoCodecMenu() {
-        showSubMenu(ITEM_VIDEO_CODEC, menuBuilder.buildVideoCodecMenu(panelState))
+        showSubMenu(ITEM_VIDEO_CODEC, menuBuilder.buildVideoCodecMenu(panelState), focusPosition = videoCodecFocusPosition())
     }
 
     private fun showAudioQualityMenu() {
-        showSubMenu(ITEM_AUDIO_QUALITY, menuBuilder.buildAudioQualityMenu(panelState))
+        showSubMenu(ITEM_AUDIO_QUALITY, menuBuilder.buildAudioQualityMenu(panelState), focusPosition = audioQualityFocusPosition())
     }
 
     private fun showAfterPlayMenu() {
-        showSubMenu(ITEM_AFTER_PLAY, menuBuilder.buildAfterPlayMenu(panelState))
+        showSubMenu(ITEM_AFTER_PLAY, menuBuilder.buildAfterPlayMenu(panelState), focusPosition = afterPlayFocusPosition())
     }
 
     private fun showScreenRatioMenu() {
-        showSubMenu(ITEM_ASPECT_RATIO, menuBuilder.buildScreenRatioMenu(panelState))
+        showSubMenu(ITEM_ASPECT_RATIO, menuBuilder.buildScreenRatioMenu(panelState), focusPosition = screenRatioFocusPosition())
     }
+
+    // All choice sub-menus have a Header as row 0, so the focused row is always selectedIndex + 1.
+
+    private fun videoQualityFocusPosition(): Int =
+        panelState.videoQualities
+            .indexOfFirst { it.id == panelState.currentVideoQuality?.id }
+            .let { if (it >= 0) it + 1 else 1 }
+
+    private fun playbackSpeedFocusPosition(): Int {
+        val speedIndex = PLAYBACK_SPEEDS.indexOfFirst { it == panelState.currentSpeed }
+        logSettingFocus("showPlaybackSpeedMenu speed=${panelState.currentSpeed} speedIndex=$speedIndex")
+        return if (speedIndex >= 0) speedIndex + 1 else 1
+    }
+
+    // Menu layout: [Header(row 0), "关闭"(row 1, currentSubtitlePosition == -1), subtitle0(row 2), subtitle1(row 3), ...].
+    // So the focused row is currentSubtitlePosition + 2: -1 -> 1 ("关闭"), 0 -> 2 (first subtitle).
+    private fun subtitleFocusPosition(): Int = panelState.currentSubtitlePosition + 2
+
+    private fun videoCodecFocusPosition(): Int =
+        panelState.videoCodecs
+            .indexOfFirst { it == panelState.currentVideoCodec }
+            .let { if (it >= 0) it + 1 else 1 }
+
+    private fun audioQualityFocusPosition(): Int =
+        panelState.audioQualities
+            .indexOfFirst { it.id == panelState.currentAudioQuality?.id }
+            .let { if (it >= 0) it + 1 else 1 }
+
+    private fun afterPlayFocusPosition(): Int =
+        menuBuilder.AFTER_PLAY_OPTIONS
+            .indexOfFirst { it.first == panelState.afterPlayMode }
+            .let { if (it >= 0) it + 1 else 1 }
+
+    private fun screenRatioFocusPosition(): Int = panelState.currentScreenRatio + 1
 
     private fun showDmSettingMenu() {
         showDmSettingMenu(animateTransition = true)
@@ -771,52 +809,61 @@ class MyPlayerSettingView @JvmOverloads constructor(
                 ITEM_VIDEO_QUALITY -> showSubMenu(
                     ITEM_VIDEO_QUALITY,
                     menuBuilder.buildVideoQualityMenu(panelState),
-                    animateTransition = false
+                    animateTransition = false,
+                    focusPosition = videoQualityFocusPosition()
                 )
                 ITEM_PLAYBACK_SPEED -> showSubMenu(
                     ITEM_PLAYBACK_SPEED,
                     menuBuilder.buildPlaybackSpeedMenu(panelState),
-                    animateTransition = false
+                    animateTransition = false,
+                    focusPosition = playbackSpeedFocusPosition()
                 )
                 ITEM_SUBTITLE -> {
                     if (panelState.subtitles.isNotEmpty()) {
                         showSubMenu(
                             ITEM_SUBTITLE,
                             menuBuilder.buildSubtitleMenu(panelState),
-                            animateTransition = false
+                            animateTransition = false,
+                            focusPosition = subtitleFocusPosition()
                         )
                     }
                 }
                 ITEM_VIDEO_CODEC -> showSubMenu(
                     ITEM_VIDEO_CODEC,
                     menuBuilder.buildVideoCodecMenu(panelState),
-                    animateTransition = false
+                    animateTransition = false,
+                    focusPosition = videoCodecFocusPosition()
                 )
                 ITEM_AFTER_PLAY -> showSubMenu(
                     ITEM_AFTER_PLAY,
                     menuBuilder.buildAfterPlayMenu(panelState),
-                    animateTransition = false
+                    animateTransition = false,
+                    focusPosition = afterPlayFocusPosition()
                 )
                 ITEM_AUDIO_QUALITY -> showSubMenu(
                     ITEM_AUDIO_QUALITY,
                     menuBuilder.buildAudioQualityMenu(panelState),
-                    animateTransition = false
+                    animateTransition = false,
+                    focusPosition = audioQualityFocusPosition()
                 )
                 ITEM_ASPECT_RATIO -> showSubMenu(
                     ITEM_ASPECT_RATIO,
                     menuBuilder.buildScreenRatioMenu(panelState),
-                    animateTransition = false
+                    animateTransition = false,
+                    focusPosition = screenRatioFocusPosition()
                 )
                 ITEM_DM_SETTING -> showDmSettingMenu(animateTransition = false)
                 ITEM_LIVE_QUALITY -> showSubMenu(
                     ITEM_LIVE_QUALITY,
                     menuBuilder.buildLiveQualityMenu(panelState),
-                    animateTransition = false
+                    animateTransition = false,
+                    focusPosition = liveQualityFocusPosition()
                 )
                 ITEM_LIVE_LINE -> showSubMenu(
                     ITEM_LIVE_LINE,
                     menuBuilder.buildLiveLineMenu(panelState),
-                    animateTransition = false
+                    animateTransition = false,
+                    focusPosition = liveLineFocusPosition()
                 )
             }
 
@@ -906,7 +953,8 @@ class MyPlayerSettingView @JvmOverloads constructor(
                 showArrow = false
             )
         }
-        submitMenuRows(menuKey = menuKey, rows = rows, animateTransition = animateTransition)
+        val focusPosition = selectedIndex + 1 // +1 to skip Header row
+        submitMenuRows(menuKey = menuKey, rows = rows, animateTransition = animateTransition, focusPosition = focusPosition)
     }
 
     private fun submitMenuRows(

--- a/app/src/main/java/com/tutu/myblbl/feature/user/FollowUserListFragment.kt
+++ b/app/src/main/java/com/tutu/myblbl/feature/user/FollowUserListFragment.kt
@@ -35,6 +35,10 @@ class FollowUserListFragment : BaseFragment<FragmentFollowUserListBinding>() {
         private const val ARG_USER_ID = "user_id"
         private const val ARG_TYPE = "type"
 
+        // 焦点恢复到列表内的轮询参数（覆盖转场动画窗口，失败后兜底返回键）
+        private const val RESTORE_FOCUS_RETRY_TIMES = 6
+        private const val RESTORE_FOCUS_RETRY_DELAY_MS = 120L
+
         fun newInstance(userId: Long, type: Int): FollowUserListFragment {
             return FollowUserListFragment().apply {
                 arguments = bundleOf(
@@ -245,10 +249,47 @@ class FollowUserListFragment : BaseFragment<FragmentFollowUserListBinding>() {
                 val targetPosition = lastFocusedPosition.coerceIn(0, adapter.itemCount - 1)
                 binding.recyclerView.scrollToPosition(targetPosition)
                 requestItemFocus(targetPosition)
+                // 轮询确认真实焦点落点（转场动画/布局未就绪窗口），失败才兜底返回键
+                retryRestoreFocus(targetPosition, retryLeft = RESTORE_FOCUS_RETRY_TIMES)
             } else {
                 requestBackFocus()
             }
         }
+    }
+
+    /**
+     * 轮询确认真实焦点是否已恢复到列表内。
+     *
+     * 背景：`requestItemFocus` 内部以 `requestFocus() == true` 判断成功，但 `requestFocus`
+     * 在 touch mode / view 未 attach / 转场动画期间可能返回 false，且重试耗尽后静默放弃；
+     * 返回值也不可靠。这里改用"焦点是否真正落在列表内"作为成功判据，覆盖转场动画窗口，
+     * 重试耗尽仍无焦点则兜底聚焦返回键，避免焦点彻底消失。
+     */
+    private fun retryRestoreFocus(targetPosition: Int, retryLeft: Int) {
+        if (!isAdded) return
+        if (hasFocusInRecyclerView()) {
+            return
+        }
+        if (retryLeft <= 0) {
+            requestBackFocus()
+            return
+        }
+        binding.recyclerView.postDelayed({
+            if (!isAdded) return@postDelayed
+            requestItemFocus(targetPosition)
+            retryRestoreFocus(targetPosition, retryLeft - 1)
+        }, RESTORE_FOCUS_RETRY_DELAY_MS)
+    }
+
+    /** 当前真实焦点是否落在用户列表 RecyclerView 内。 */
+    private fun hasFocusInRecyclerView(): Boolean {
+        val focused = binding.recyclerView.rootView?.findFocus() ?: return false
+        var v: View? = focused
+        while (v != null) {
+            if (v === binding.recyclerView) return true
+            v = v.parent as? View
+        }
+        return false
     }
 
     private fun requestBackFocus() {

--- a/app/src/main/java/com/tutu/myblbl/ui/activity/MarmotLiveActivity.kt
+++ b/app/src/main/java/com/tutu/myblbl/ui/activity/MarmotLiveActivity.kt
@@ -202,13 +202,23 @@ class MarmotLiveActivity : BaseActivity<ActivityMarmotLiveBinding>() {
             useX5 = useX5,
             jsBridge = jsBridge,
             onProgress = { progress ->
-                binding.progressBar.visibility = if (progress in 1..99) View.VISIBLE else View.GONE
+                // 遮罩显示期间保持加载转圈可见（阶段文字由 videoCoverPollRunnable 按 <video> 是否创建判定）
+                if (binding.videoCover.visibility == View.VISIBLE) {
+                    binding.progressBar.visibility = View.VISIBLE
+                } else {
+                    binding.progressBar.visibility = if (progress in 1..99) View.VISIBLE else View.GONE
+                }
             },
             onPageLoaded = { url ->
-                val vod = MarmotLiveData.getByUrl(url)
-                if (vod != null) {
-                    currentVod = vod
-                    showLiveName(vod.name)
+                // 注意：这里不再调用 showLiveName。
+                // 频道名提示已在 goNext / playCurrent / 频道列表选台时显示。
+                // 若在此再次显示，实机 WebView 加载慢时 onPageLoaded 可能在
+                // showLiveName 的 2s 隐藏计时触发后才回调，导致「频道名消失后又出现」的闪断。
+                // 因此页面加载完成仅负责驱动遮罩轮询，不再重复显示频道名。
+                // 页面加载完成：遮罩下的阶段文字由 videoCoverPollRunnable 按 <video> 是否创建判定，
+                // 这里无需干预，轮询已在 showVideoCover 启动
+                if (binding.videoCover.visibility == View.VISIBLE) {
+                    startVideoCoverPolling()
                 }
             },
             onShowCustomView = { customView ->
@@ -223,6 +233,9 @@ class MarmotLiveActivity : BaseActivity<ActivityMarmotLiveBinding>() {
                 )
                 binding.fullscreenContainer.visibility = View.VISIBLE
                 binding.webviewWrapper.visibility = View.GONE
+                // 注意：不再在此移除遮罩。onShowCustomView 可能在视频刚进全屏但尚未真正出画面时过早触发，
+                // 过早移除会露出仍在加载的网页。遮罩移除统一由 videoCoverPollRunnable 检测到
+                // <video> 真正播放（currentTime>0 连续 2 次）或 60s 兜底来主导。
             },
             onHideCustomView = {
                 binding.fullscreenContainer.removeAllViews()
@@ -257,34 +270,34 @@ class MarmotLiveActivity : BaseActivity<ActivityMarmotLiveBinding>() {
                 return@launch
             }
             provinces.clear()
-            // 方案 C（CCTV 优先）：只保留能用 createLivePlayer 播放的 CCTV 频道
-            // （url 含 tv.cctv.com/live/）。省台/央视频等暂不显示（后续逐站点维护再加）。
+            // 【放开全部频道】不再按 CCTV 过滤，直接用 tv2.json 全量频道（央视/央视源2/卫视/各省台/地市台等）。
+            // 播放链路统一走 playCurrent：CCTV（tv.cctv.com/live/）用 createLivePlayer 原生播放，
+            // 其它源用 Marmot 整页劫持（loadUrl + tv.user.js 注入 + 对应站点 detail.js）。
+            // 注意：当前是「全放开」状态，用于逐个站点实测哪些源能正常出流，实测后再收敛为白名单/分级。
             val allLives = MarmotLiveData.getLives()
-            var cctvIndex = 0
+            var liveIndex = 0
             for (live in allLives) {
-                // 筛选该分组下 url 是 tv.cctv.com/live/ 的频道，重建 Vod 的导航索引
-                val cctvVods = live.vods.filter { extractCctvChannelId(it.url) != null }
-                if (cctvVods.isEmpty()) continue
-                // 构造只含 CCTV 频道的分组副本（重新编 tagIndex/detailIndex）
-                val filteredLive = Live(tag = live.tag, name = live.name, index = cctvIndex,
-                    vods = cctvVods.toMutableList())
-                cctvVods.forEachIndexed { j, vod ->
-                    vod.tagIndex = cctvIndex
+                if (live.vods.isEmpty()) continue
+                // 构造分组副本（重新编 tagIndex/detailIndex）
+                val filteredLive = Live(tag = live.tag, name = live.name, index = liveIndex,
+                    vods = live.vods.toMutableList())
+                live.vods.forEachIndexed { j, vod ->
+                    vod.tagIndex = liveIndex
                     vod.detailIndex = j
-                    vod.key = "${cctvIndex}_$j"
+                    vod.key = "${liveIndex}_$j"
                 }
                 provinces.add(filteredLive)
-                cctvIndex++
+                liveIndex++
             }
-            AppLog.i(TAG, "initData: CCTV 频道过滤后 ${provinces.size} 个分组，" +
+            AppLog.i(TAG, "initData: 全量频道 ${provinces.size} 个分组，" +
                 "${provinces.sumOf { it.vods.size }} 个频道")
             if (provinces.isEmpty()) {
-                Toast.makeText(this@MarmotLiveActivity, "无 CCTV 频道数据", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this@MarmotLiveActivity, "无频道数据", Toast.LENGTH_SHORT).show()
                 return@launch
             }
-            // 3. 恢复上次观看频道：优先按保存的 URL 反查（必须是 CCTV 频道），否则回退首个 CCTV 频道
+            // 3. 恢复上次观看频道：优先按保存的 URL 反查（任意源），否则回退首频道
             val lastUrl = appSettings.getCachedString(KEY_LAST_CHANNEL_URL, null)
-            currentVod = if (!lastUrl.isNullOrEmpty() && extractCctvChannelId(lastUrl) != null) {
+            currentVod = if (!lastUrl.isNullOrEmpty()) {
                 provinces.flatMap { it.vods }.firstOrNull { it.url == lastUrl }
                     ?: provinces.first().vods.first()
             } else {
@@ -311,10 +324,16 @@ class MarmotLiveActivity : BaseActivity<ActivityMarmotLiveBinding>() {
                 "#${com.tutu.myblbl.feature.marmot.web.MarmotSystemWebViewClient.MYBILI_CCTV_NATIVE_MARKER}"
             val html = buildCctvPlayerHtml(channelId, cctvQualityProvider.current.br)
             AppLog.i(TAG, "playCurrent: CCTV 原生播放 channelId=$channelId quality=${cctvQualityProvider.current.label}")
+            // CCTV 自构 HTML 无网页闪现，确保清掉可能残留的遮罩
+            hideVideoCover()
             webEngine?.loadDataWithBaseURL(baseUrl, html)
         } else {
             AppLog.i(TAG, "playCurrent: Marmot 模式 url=${vod.url}")
-            webEngine?.loadUrl(vod.url)
+            // 非 CCTV 整页劫持：先显示全黑遮罩，并确保遮罩真正绘制上屏后再加载官网网页，
+            // 避免 WebView 首帧快于遮罩布局导致官网网页闪现
+            showVideoCover {
+                webEngine?.loadUrl(vod.url)
+            }
         }
         showLiveName(vod.name)
         // 记录上次观看频道（IO 写入，不阻塞）
@@ -390,11 +409,128 @@ $scriptTags
         """.trimIndent()
     }
 
-    /** 短暂显示频道名（2 秒后清除）。 */
+    /** 短暂显示频道名（2 秒后清除）。同一频道被 playCurrent / onPageLoaded 等多次调用时会重置计时，不会中途闪断。 */
     private fun showLiveName(name: String) {
+        mainHandler.removeCallbacks(hideLiveNameRunnable)
         binding.liveName.text = name
         binding.liveName.visibility = View.VISIBLE
-        mainHandler.postDelayed({ binding.liveName.visibility = View.GONE }, 2000)
+        mainHandler.postDelayed(hideLiveNameRunnable, 2000)
+    }
+
+    private val hideLiveNameRunnable = Runnable { binding.liveName.visibility = View.GONE }
+
+    // ==================== 全黑遮罩（非 CCTV 整页劫持加载期间盖住官网网页） ====================
+
+    /** 遮罩最常驻时长：超过后强制移除，防止视频迟迟不出导致黑屏卡死。 */
+    private val videoCoverTimeoutMs = 60_000L
+
+    /**
+     * 显示全黑遮罩盖住 WebView，避免非 CCTV 整页劫持加载期间闪现官网网页。
+     *
+     * 关键：用 [android.view.View.post] 确保遮罩**真正布局并绘制上屏**后再执行 [afterShown]
+     * （通常是加载官网网页），从而彻底盖住网页的加载/渲染过程，杜绝首帧闪现。
+     *
+     * 遮罩显示期间同时显示居中的加载进度转圈（[binding.progressBar]），给用户明确的加载提示。
+     * 视频就绪（[hideVideoCover] 由轮询检测到播放触发）或超时后自动移除。
+     */
+    private fun showVideoCover(afterShown: (() -> Unit)? = null) {
+        mainHandler.removeCallbacks(hideVideoCoverRunnable)
+        if (binding.videoCover.visibility != View.VISIBLE) {
+            binding.videoCover.visibility = View.VISIBLE
+        }
+        // 显示加载进度转圈与状态文字提示（位于遮罩之上）
+        binding.progressBar.visibility = View.VISIBLE
+        updateVideoCoverText("正在初始化…")
+        // 定时兜底：防止某些源视频迟迟不出导致遮罩一直黑屏
+        mainHandler.postDelayed(hideVideoCoverRunnable, videoCoverTimeoutMs)
+        // 遮罩绘制上屏后再执行 afterShown（loadUrl），确保网页全程在遮罩背后渲染
+        binding.videoCover.post {
+            if (binding.videoCover.visibility == View.VISIBLE) {
+                afterShown?.invoke()
+                // 遮罩期间持续轮询，按 <video> 是否创建/播放判定"正在加载网页/正在加载视频/就绪移除"
+                startVideoCoverPolling()
+            }
+        }
+    }
+
+    /** 移除遮罩（视频就绪或超时），并停止视频播放轮询。 */
+    private fun hideVideoCover() {
+        mainHandler.removeCallbacks(hideVideoCoverRunnable)
+        mainHandler.removeCallbacks(videoCoverPollRunnable)
+        if (binding.videoCover.visibility != View.GONE) {
+            binding.videoCover.visibility = View.GONE
+        }
+        // 遮罩移除时隐藏加载进度与状态文字
+        binding.progressBar.visibility = View.GONE
+        binding.videoCoverText.visibility = View.GONE
+    }
+
+    /** 更新遮罩层上的加载状态文字（仅遮罩显示期间生效）。 */
+    private fun updateVideoCoverText(text: String) {
+        if (binding.videoCover.visibility != View.VISIBLE) return
+        if (binding.videoCoverText.visibility != View.VISIBLE) {
+            binding.videoCoverText.visibility = View.VISIBLE
+        }
+        binding.videoCoverText.text = text
+    }
+
+    private val hideVideoCoverRunnable = Runnable { hideVideoCover() }
+
+    /** 轮询检测页面 `<video>` 是否真正开始播放（持续播放），一旦确认即移除遮罩（每 500ms 一次）。 */
+    private fun startVideoCoverPolling() {
+        videoCoverPlayingCount = 0
+        videoCoverLastTime = 0.0
+        mainHandler.removeCallbacks(videoCoverPollRunnable)
+        mainHandler.post(videoCoverPollRunnable)
+    }
+
+    /** 视频连续播放检测计数（每次启动轮询重置）。 */
+    private var videoCoverPlayingCount = 0
+
+    /** 上一次轮询到的 <video> currentTime，用于判断时间轴是否在增长（真正在播放），避免静止误判。 */
+    private var videoCoverLastTime = 0.0
+
+    private val videoCoverPollRunnable: Runnable = object : Runnable {
+        override fun run() {
+            // 遮罩已移除则停止轮询
+            if (binding.videoCover.visibility == View.GONE) return
+            // 返回 <video> 的 currentTime：-1=无 video；0=有 video 未播；>0=时间轴（判断是否增长）
+            webEngine?.evaluateJavascriptWithResult(
+                "(function(){try{var v=document.querySelector('video');" +
+                    "if(!v){return '-1';}" +
+                    "return (v.currentTime||0)+'';" +
+                    "}catch(e){return '-1';}})();"
+            ) { result ->
+                val timeStr = result?.trim()?.removeSurrounding("\"")
+                val time = timeStr?.toDoubleOrNull() ?: -1.0
+                when {
+                    // 页面尚未创建 <video>，仍处于网页加载阶段
+                    time < 0 -> {
+                        videoCoverPlayingCount = 0
+                        videoCoverLastTime = 0.0
+                        updateVideoCoverText("正在加载网页…")
+                    }
+                    // 已创建 <video> 但尚未真正播放（currentTime 未前进）
+                    time == 0.0 || time <= videoCoverLastTime -> {
+                        videoCoverPlayingCount = 0
+                        videoCoverLastTime = time
+                        updateVideoCoverText("正在加载视频…")
+                    }
+                    // 时间轴在增长，确认真正在播放；连续多次才移除遮罩，避免骨架/静止 video 误判
+                    else -> {
+                        videoCoverLastTime = time
+                        if (++videoCoverPlayingCount >= 2) {
+                            AppLog.i(TAG, "视频时间轴持续增长，移除遮罩")
+                            hideVideoCover()
+                            return@evaluateJavascriptWithResult
+                        }
+                    }
+                }
+                if (binding.videoCover.visibility != View.GONE) {
+                    mainHandler.postDelayed(videoCoverPollRunnable, 500)
+                }
+            }
+        }
     }
 
     // ==================== 频道列表浮层（确认键弹出）====================

--- a/app/src/main/res/layout/activity_marmot_live.xml
+++ b/app/src/main/res/layout/activity_marmot_live.xml
@@ -14,6 +14,16 @@
         android:layout_height="match_parent"
         android:background="@color/black" />
 
+    <!-- 全黑遮罩：非 CCTV 整页劫持加载期间盖住官网网页，视频就绪后移除，避免网页 UI 闪现 -->
+    <View
+        android:id="@+id/video_cover"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/black"
+        android:clickable="false"
+        android:focusable="false"
+        android:visibility="gone" />
+
     <!-- 全屏视频容器（部分直播页 onShowCustomView 用） -->
     <FrameLayout
         android:id="@+id/fullscreen_container"
@@ -22,12 +32,30 @@
         android:background="@color/black"
         android:visibility="gone" />
 
-    <!-- 加载进度 -->
+    <!-- 加载进度转圈 -->
     <ProgressBar
         android:id="@+id/progress_bar"
         android:layout_width="@dimen/px100"
         android:layout_height="@dimen/px100"
         android:layout_gravity="center"
+        android:layout_marginTop="@dimen/px60"
+        android:visibility="gone" />
+
+    <!-- 加载状态文字（遮罩层上的加载进度提示） -->
+    <TextView
+        android:id="@+id/video_cover_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginTop="@dimen/px200"
+        android:background="@drawable/transparent_black_bg"
+        android:paddingStart="@dimen/px30"
+        android:paddingTop="@dimen/px15"
+        android:paddingEnd="@dimen/px30"
+        android:paddingBottom="@dimen/px15"
+        android:textColor="@android:color/white"
+        android:textSize="@dimen/px32"
+        android:textStyle="bold"
         android:visibility="gone" />
 
     <!-- 当前频道名提示（切台时短暂显示） -->

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -XX:ReservedCodeCacheSize=256m -Dfile.encoding=UTF-8 -Dcom.android.tools.r8.threadCount=1
+org.gradle.workers.max=2
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true


### PR DESCRIPTION
本 PR 包含 7 个提交，均基于当前上游 main (v1.6.10)，无分叉可直接合并。

功能修复：
- 优化弹幕时间轴平滑收敛，修复弹幕统一大幅跳跃问题
- 修复播放设置各子菜单打开时焦点错误定位，统一修正定位到当前选中项
- 修复倍速菜单打开时焦点跳动到首项、未定位到当前速度项的问题
- 修复网格直播列表下键跳行不稳定会跨行跳选问题
- 新增 VideoCardFocusHelper，统一视频卡片焦点处理

构建与仓库优化（无业务影响）：
- app/build.gradle.kts：applicationId 支持 -P 参数覆盖，默认仍为 com.tutu.myblbl
- gradle.properties：限制 R8 线程与构建内存，降低崩溃风险
- .gitignore：忽略 .codebuddy/

已验证：编译通过。